### PR TITLE
feat: batch child bounties

### DIFF
--- a/src/Transactions.tsx
+++ b/src/Transactions.tsx
@@ -35,7 +35,6 @@ export function trackTransaction(tx$: Observable<TxEvent>) {
                 render: "Waiting for confirmation…",
               }
             : {
-                type: "warning",
                 render:
                   "Transaction included in a block but is failing: " +
                   JSON.stringify(res.dispatchError),

--- a/src/components/AccountSelector/AccountInput.tsx
+++ b/src/components/AccountSelector/AccountInput.tsx
@@ -93,7 +93,7 @@ export const AccountInput: FC<{
           role="combobox"
           aria-expanded={open}
           className={twMerge(
-            "flex w-64 justify-between overflow-hidden px-2 border border-border bg-input",
+            "flex w-64 justify-between overflow-hidden px-2 border border-border bg-background",
             className
           )}
           forceSvgSize={false}
@@ -103,6 +103,7 @@ export const AccountInput: FC<{
               value={value}
               name={hintedValue?.name}
               className="overflow-hidden"
+              copyable={false}
             />
           ) : (
             <span className="opacity-80">Select…</span>

--- a/src/components/CopyText.tsx
+++ b/src/components/CopyText.tsx
@@ -32,6 +32,7 @@ export const CopyText: React.FC<
       className={twMerge(className, disabled ? "opacity-50" : "")}
       type="button"
       onClick={copy}
+      tabIndex={-1}
     >
       {copied ? (
         <CheckCircle size={16} className="text-green-500 dark:text-green-300" />

--- a/src/components/TokenInput.tsx
+++ b/src/components/TokenInput.tsx
@@ -19,9 +19,10 @@ export const TokenInput = forwardRef<
       symbol: string;
       decimals: number;
     };
+    placeholder?: string;
     className?: string;
   }
->(({ value: value, onChange, token, className }, outerRef) => {
+>(({ value, placeholder, onChange, token, className }, outerRef) => {
   const ref = useRef<HTMLInputElement>(null as unknown as HTMLInputElement);
 
   useEffect(() => {
@@ -72,18 +73,19 @@ export const TokenInput = forwardRef<
     <div
       ref={outerRef}
       className={twMerge(
-        "flex gap-2 py-1 px-2 border rounded items-center",
+        "flex overflow-hidden h-10 gap-2 py-1 px-2 border rounded-md items-center ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
         className
       )}
     >
       <input
-        className="outline-none flex-1"
+        className="outline-none flex-1 flex-shrink block min-w-0"
         ref={ref}
         type="text"
+        placeholder={placeholder}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
       />
-      <div className="text-slate-600">{token.symbol}</div>
+      <div className="text-slate-600 flex-shrink-0">{token.symbol}</div>
     </div>
   );
 });

--- a/src/pages/Bounty/ActiveBounty.tsx
+++ b/src/pages/Bounty/ActiveBounty.tsx
@@ -29,6 +29,7 @@ import {
 } from "./ChildBounty/childBounties.state";
 import { ChildBounty as SdkChildBounty } from "./ChildBounty/ChildBounty";
 import { bountyCuratorSigner$ } from "./curatorSigner";
+import { BatchChildBounties } from "./BatchChildBounties";
 
 export const ActiveBounty: FC<{
   bounty: SdkActiveBounty;
@@ -77,7 +78,7 @@ export const ActiveBounty: FC<{
             </BountyDetails>
             <BountyActions bounty={bounty} />
             <ChildBounties id={bounty.id} />
-            <div>
+            <div className="flex justify-between">
               <TransactionDialog
                 signer={curatorSigner}
                 dialogContent={(onSubmit) => (
@@ -85,6 +86,18 @@ export const ActiveBounty: FC<{
                 )}
               >
                 Create Child Bounty
+              </TransactionDialog>
+              <TransactionDialog
+                signer={curatorSigner}
+                dialogContent={(onSubmit) => (
+                  <BatchChildBounties
+                    curator={bounty.curator}
+                    id={bounty.id}
+                    onSubmit={onSubmit}
+                  />
+                )}
+              >
+                Batch Child Bounties
               </TransactionDialog>
             </div>
           </>

--- a/src/pages/Bounty/BatchChildBounties.tsx
+++ b/src/pages/Bounty/BatchChildBounties.tsx
@@ -1,0 +1,227 @@
+import { client, typedApi } from "@/chain";
+import { AccountInput } from "@/components/AccountSelector/AccountInput";
+import { formatValue } from "@/components/token-formatter";
+import { DOT_TOKEN, TokenInput } from "@/components/TokenInput";
+import { Button } from "@/components/ui/button";
+import {
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { usePromise } from "@/lib/usePromise";
+import { MultiAddress } from "@polkadot-api/descriptors";
+import { state, useStateObservable } from "@react-rxjs/core";
+import { Trash2 } from "lucide-react";
+import { Binary, SS58String, Transaction } from "polkadot-api";
+import { FC, useState } from "react";
+import { catchError } from "rxjs";
+import { twMerge } from "tailwind-merge";
+
+interface ChildRow {
+  name: string;
+  amount: bigint | null;
+  recipient: SS58String;
+}
+const emptyRow: ChildRow = {
+  name: "",
+  amount: null,
+  recipient: "",
+};
+
+// For an upcoming change not yet released as a wasm which is significant
+const unsafeApi = client.getUnsafeApi();
+const nextChildId$ = state(
+  (id: number) =>
+    unsafeApi.query.ChildBounties.ParentTotalChildBounties.watchValue(id).pipe(
+      catchError(() =>
+        typedApi.query.ChildBounties.ChildBountyCount.watchValue()
+      )
+    ),
+  null
+);
+
+interface BatchChildBountiesProps {
+  id: number;
+  curator: SS58String;
+  onSubmit: (tx: Transaction<any, any, any, any>) => void;
+}
+
+export const BatchChildBounties: FC<BatchChildBountiesProps> = (props) => {
+  return (
+    <DialogContent className="max-w-screen-md max-h-full overflow-hidden flex flex-col">
+      <DialogHeader>
+        <DialogTitle>Batch Child Bounties</DialogTitle>
+        <DialogDescription>
+          Create direct payouts for this bounty using child bounties
+        </DialogDescription>
+      </DialogHeader>
+      <BatchChildBountiesForm {...props} />
+    </DialogContent>
+  );
+};
+
+const BatchChildBountiesForm: FC<BatchChildBountiesProps> = ({
+  id,
+  curator,
+  onSubmit,
+}) => {
+  const [rows, setRows] = useState<ChildRow[]>([]);
+  const childId = useStateObservable(nextChildId$(id));
+  const minimumValue = usePromise(
+    async () => typedApi.constants.ChildBounties.ChildBountyValueMinimum(),
+    null
+  );
+
+  const isValid =
+    childId != null &&
+    rows.length &&
+    minimumValue != null &&
+    rows.every(
+      (r) => r.amount != null && r.amount >= minimumValue && r.recipient
+    );
+
+  const submit = () => {
+    if (!isValid) return null;
+
+    const calls = [
+      typedApi.tx.System.remark({
+        remark: Binary.fromText(
+          "Transaction created with https://bounties.usepapi.app/"
+        ),
+      }).decodedCall,
+      ...rows.flatMap((row, i) => [
+        typedApi.tx.ChildBounties.add_child_bounty({
+          description: Binary.fromText(row.name),
+          parent_bounty_id: id,
+          value: row.amount!,
+        }).decodedCall,
+        typedApi.tx.ChildBounties.propose_curator({
+          parent_bounty_id: id,
+          child_bounty_id: childId + i,
+          curator: MultiAddress.Id(curator),
+          fee: 0n,
+        }).decodedCall,
+        typedApi.tx.ChildBounties.accept_curator({
+          parent_bounty_id: id,
+          child_bounty_id: childId + i,
+        }).decodedCall,
+        typedApi.tx.ChildBounties.award_child_bounty({
+          parent_bounty_id: id,
+          child_bounty_id: childId + i,
+          beneficiary: MultiAddress.Id(row.recipient),
+        }).decodedCall,
+        typedApi.tx.ChildBounties.claim_child_bounty({
+          parent_bounty_id: id,
+          child_bounty_id: childId + i,
+        }).decodedCall,
+      ]),
+    ];
+
+    const tx = typedApi.tx.Utility.batch_all({
+      calls,
+    });
+    onSubmit(tx);
+  };
+
+  const rowUpdater = (index: number, prop: keyof ChildRow) => (value: any) =>
+    setRows((rows) => {
+      if (index === rows.length) {
+        return [
+          ...rows,
+          {
+            ...emptyRow,
+            [prop]: value,
+          },
+        ];
+      }
+      return rows.map((row, i) =>
+        i === index
+          ? {
+              ...row,
+              [prop]: value,
+            }
+          : row
+      );
+    });
+
+  return (
+    <div className="overflow-auto px-1 space-y-4">
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th className="w-full">Description</th>
+            <th>Amount</th>
+            <th>Beneficiary</th>
+          </tr>
+        </thead>
+        <tbody>
+          {[...rows, emptyRow].map((row, i) => (
+            <tr key={i}>
+              <td>
+                <button
+                  className={twMerge(
+                    "text-destructive",
+                    i == rows.length ? "invisible" : ""
+                  )}
+                  tabIndex={-1}
+                  onClick={() =>
+                    setRows((rows) => rows.filter((_, id) => id !== i))
+                  }
+                >
+                  <Trash2 />
+                </button>
+              </td>
+              <td className="p-1">
+                <Input
+                  placeholder="Child bounty description"
+                  value={row.name}
+                  onChange={(evt) => rowUpdater(i, "name")(evt.target.value)}
+                />
+              </td>
+              <td className="p-1">
+                <TokenInput
+                  className="w-40"
+                  placeholder="0.00"
+                  token={DOT_TOKEN}
+                  value={row.amount}
+                  onChange={rowUpdater(i, "amount")}
+                />
+              </td>
+              <td className="p-1">
+                <AccountInput
+                  value={row.recipient}
+                  onChange={rowUpdater(i, "recipient")}
+                />
+              </td>
+            </tr>
+          ))}
+          <tr>
+            <td></td>
+            <td></td>
+            <td className="text-sm text-muted-foreground text-center">
+              (min value:{" "}
+              {minimumValue != null
+                ? formatValue(minimumValue, DOT_TOKEN.decimals, true)
+                : "…"}
+              )
+            </td>
+            <td></td>
+          </tr>
+        </tbody>
+      </table>
+      <div className="flex justify-between items-start gap-2">
+        <div className="text-sm text-muted-foreground">
+          Note: This transaction will only work for the current child bounty
+          count. It might fail if someone creates another child bounty while
+          it's getting approved.
+        </div>
+        <Button disabled={!isValid} onClick={submit}>
+          Submit
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/Bounty/ChildBounty/childBounties.state.ts
+++ b/src/pages/Bounty/ChildBounty/childBounties.state.ts
@@ -2,15 +2,12 @@ import { typedApi } from "@/chain";
 import { getLinkedSigner$ } from "@/state/linkedSigners";
 import { createChildBountiesSdk } from "@polkadot-api/sdk-governance";
 import { state } from "@react-rxjs/core";
-import { map, of, switchMap, tap } from "rxjs";
+import { map, of, switchMap } from "rxjs";
 
 export const childBountiesSdk = createChildBountiesSdk(typedApi);
 
 export const childBountyKeys$ = state(
-  (parentId: number) =>
-    childBountiesSdk
-      .watch(parentId)
-      .bountyIds$.pipe(tap((v) => console.log("child bounty keys", v))),
+  (parentId: number) => childBountiesSdk.watch(parentId).bountyIds$,
   null
 );
 


### PR DESCRIPTION
This adds a modal on the active bounty page to batch child bounty payouts

![image](https://github.com/user-attachments/assets/7648606c-6fe3-4d68-91ee-5b47db3d65db)


This creates a batch transaction that creates one child bounty per each row, and progresses them through all the stages.